### PR TITLE
refactor: Type check and restructure tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 .mf
 .env
 .dev.vars
+.wrangler

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@cloudflare/workers-types": "^4.20231218.0",
         "@types/chai": "^5.0.0",
         "@types/mocha": "^10.0.9",
+        "@types/node-fetch": "^2.6.11",
         "@types/sinon": "^17.0.3",
         "@ucanto/principal": "^8.1.0",
         "@web3-storage/content-claims": "^5.0.0",
@@ -3301,6 +3302,17 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
     "node_modules/@types/node-forge": {
       "version": "1.3.11",
       "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.11.tgz",
@@ -4280,6 +4292,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/atomically": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.3.tgz",
@@ -4606,6 +4625,19 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -4983,6 +5015,16 @@
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
       "dev": true
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -6046,6 +6088,21 @@
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/freeport-promise": {
@@ -8075,6 +8132,29 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,9 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20231218.0",
+        "@types/chai": "^5.0.0",
+        "@types/mocha": "^10.0.9",
+        "@types/sinon": "^17.0.3",
         "@ucanto/principal": "^8.1.0",
         "@web3-storage/content-claims": "^5.0.0",
         "@web3-storage/public-bucket": "^1.1.0",
@@ -3252,6 +3255,12 @@
         "@stablelib/wipe": "^1.0.1"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.0.0.tgz",
+      "integrity": "sha512-+DwhEHAaFPPdJ2ral3kNHFQXnTfscEEFsUxzD+d7nlcLrFK23JtNjH71RGasTcHb88b4vVi4mTyfpf8u2L8bdA==",
+      "dev": true
+    },
     "node_modules/@types/dns-packet": {
       "version": "5.6.5",
       "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.5.tgz",
@@ -3278,6 +3287,12 @@
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
       "dev": true
     },
+    "node_modules/@types/mocha": {
+      "version": "10.0.9",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.9.tgz",
+      "integrity": "sha512-sicdRoWtYevwxjOHNMPTl3vSfJM6oyW8o1wXeI7uww6b6xHg8eBznQDNSGBCDJmsE8UMxP05JgZRtsKbTqt//Q==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "20.14.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.0.tgz",
@@ -3299,6 +3314,21 @@
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+    },
+    "node_modules/@types/sinon": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
+      "integrity": "sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true
     },
     "node_modules/@ucanto/client": {
       "version": "9.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "sinon": "^19.0.2",
         "standard": "^17.1.0",
         "tree-kill": "^1.2.2",
-        "typescript": "^5.3.3",
+        "typescript": "^5.6.3",
         "wrangler": "^3.78.8"
       }
     },
@@ -10089,10 +10089,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20231218.0",
+    "@types/chai": "^5.0.0",
+    "@types/mocha": "^10.0.9",
+    "@types/sinon": "^17.0.3",
     "@ucanto/principal": "^8.1.0",
     "@web3-storage/content-claims": "^5.0.0",
     "@web3-storage/public-bucket": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "sinon": "^19.0.2",
     "standard": "^17.1.0",
     "tree-kill": "^1.2.2",
-    "typescript": "^5.3.3",
+    "typescript": "^5.6.3",
     "wrangler": "^3.78.8"
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@cloudflare/workers-types": "^4.20231218.0",
     "@types/chai": "^5.0.0",
     "@types/mocha": "^10.0.9",
+    "@types/node-fetch": "^2.6.11",
     "@types/sinon": "^17.0.3",
     "@ucanto/principal": "^8.1.0",
     "@web3-storage/content-claims": "^5.0.0",

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -1,29 +1,11 @@
-import type { R2Bucket, KVNamespace, RateLimit } from '@cloudflare/workers-types'
+import type { R2Bucket } from '@cloudflare/workers-types'
 import { CID } from '@web3-storage/gateway-lib/handlers'
-import { RATE_LIMIT_EXCEEDED } from './constants.js'
+import { Environment as RateLimiterEnvironment } from './handlers/rate-limiter.types.ts'
 
-export { }
-
-export interface Environment {
+export interface Environment extends RateLimiterEnvironment {
   VERSION: string
-  DEBUG: string
   CARPARK: R2Bucket
   CONTENT_CLAIMS_SERVICE_URL?: string
-  ACCOUNTING_SERVICE_URL: string
-  RATE_LIMITER: RateLimit
-  AUTH_TOKEN_METADATA: KVNamespace
-  FF_RATE_LIMITER_ENABLED: string
-}
-
-export type RateLimitExceeded = typeof RATE_LIMIT_EXCEEDED[keyof typeof RATE_LIMIT_EXCEEDED]
-
-export interface RateLimitService {
-  check: (cid: CID, req: Request) => Promise<RateLimitExceeded>
-}
-
-export interface TokenMetadata {
-  locationClaim?: unknown // TODO: figure out the right type to use for this - we probably need it for the private data case to verify auth
-  invalid?: boolean
 }
 
 export interface AccountingService {

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -1,10 +1,9 @@
-import type { R2Bucket } from '@cloudflare/workers-types'
 import { CID } from '@web3-storage/gateway-lib/handlers'
 import { Environment as RateLimiterEnvironment } from './handlers/rate-limiter.types.ts'
+import { Environment as CarBlockEnvironment } from './handlers/car-block.types.ts'
 
-export interface Environment extends RateLimiterEnvironment {
+export interface Environment extends CarBlockEnvironment, RateLimiterEnvironment {
   VERSION: string
-  CARPARK: R2Bucket
   CONTENT_CLAIMS_SERVICE_URL?: string
 }
 

--- a/src/handlers/car-block.js
+++ b/src/handlers/car-block.js
@@ -7,14 +7,17 @@ import { base58btc } from 'multiformats/bases/base58'
 import { CAR_CODE } from '../constants.js'
 
 /**
- * @typedef {import('@web3-storage/gateway-lib').IpfsUrlContext} CarBlockHandlerContext
- * @typedef {{ offset: number, length?: number } | { offset?: number, length: number } | { suffix: number }} Range
+ * @import { Context, IpfsUrlContext as CarBlockHandlerContext, Handler } from '@web3-storage/gateway-lib'
+ * @import { R2Bucket, KVNamespace, RateLimit } from '@cloudflare/workers-types'
+ * @import { Environment } from './car-block.types.js'
  */
+
+/** @typedef {{ offset: number, length?: number } | { offset?: number, length: number } | { suffix: number }} Range */
 
 /**
  * Handler that serves CAR files directly from R2.
  *
- * @type {import('@web3-storage/gateway-lib').Handler<CarBlockHandlerContext, import('../bindings.js').Environment>}
+ * @type {Handler<CarBlockHandlerContext, Environment>}
  */
 export async function handleCarBlock (request, env, ctx) {
   const { searchParams, dataCid } = ctx

--- a/src/handlers/car-block.types.ts
+++ b/src/handlers/car-block.types.ts
@@ -1,0 +1,6 @@
+import { Environment as MiddlewareEnvironment } from '@web3-storage/gateway-lib'
+import { R2Bucket } from '@cloudflare/workers-types'
+
+export interface Environment extends MiddlewareEnvironment {
+  CARPARK: R2Bucket
+}

--- a/src/handlers/rate-limiter.types.ts
+++ b/src/handlers/rate-limiter.types.ts
@@ -1,0 +1,22 @@
+import { CID } from '@web3-storage/gateway-lib/handlers'
+import { Environment as MiddlewareEnvironment } from '@web3-storage/gateway-lib'
+import { KVNamespace, RateLimit } from '@cloudflare/workers-types'
+import { RATE_LIMIT_EXCEEDED } from './../constants.js'
+
+export interface Environment extends MiddlewareEnvironment {
+  ACCOUNTING_SERVICE_URL: string
+  RATE_LIMITER: RateLimit
+  AUTH_TOKEN_METADATA: KVNamespace
+  FF_RATE_LIMITER_ENABLED: string
+}
+
+export interface TokenMetadata {
+  locationClaim?: unknown // TODO: figure out the right type to use for this - we probably need it for the private data case to verify auth
+  invalid?: boolean
+}
+
+export type RateLimitExceeded = typeof RATE_LIMIT_EXCEEDED[keyof typeof RATE_LIMIT_EXCEEDED]
+
+export interface RateLimitService {
+  check: (cid: CID, req: Request) => Promise<RateLimitExceeded>
+}

--- a/test/fixtures/worker-fixture.js
+++ b/test/fixtures/worker-fixture.js
@@ -6,7 +6,7 @@ import { runWranglerDev } from '../helpers/run-wrangler.js'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
-/** 
+/**
  * The wrangler environment to use for the test worker.
  * @type {string}
  */
@@ -25,7 +25,7 @@ const wranglerEnv = process.env.WRANGLER_ENV || 'integration'
  * Worker information object
  * @type {WorkerInfo | undefined}
  */
-let workerInfo;
+let workerInfo
 
 /**
  * Sets up the test worker.
@@ -54,7 +54,7 @@ export const mochaGlobalSetup = async () => {
  */
 export const mochaGlobalTeardown = async () => {
   // If the worker is not running, nothing to do.
-  if (!workerInfo) return;
+  if (!workerInfo) return
 
   try {
     const { stop } = workerInfo
@@ -72,6 +72,6 @@ export const mochaGlobalTeardown = async () => {
  * @returns {WorkerInfo}
  */
 export function getWorkerInfo () {
-  if (!workerInfo) throw new Error('Worker not running.');
+  if (!workerInfo) throw new Error('Worker not running.')
   return workerInfo
 }

--- a/test/fixtures/worker-fixture.js
+++ b/test/fixtures/worker-fixture.js
@@ -6,6 +6,12 @@ import { runWranglerDev } from '../helpers/run-wrangler.js'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
+/** 
+ * The wrangler environment to use for the test worker.
+ * @type {string}
+ */
+const wranglerEnv = process.env.WRANGLER_ENV || 'integration'
+
 /**
  * Worker information object
  * @typedef {Object} WorkerInfo
@@ -13,20 +19,13 @@ const __dirname = path.dirname(__filename)
  * @property {number | undefined} port - The port of the test worker.
  * @property {() => Promise<void> | undefined} stop - Function to stop the test worker.
  * @property {() => string | undefined} getOutput - Function to get the output of the test worker.
- * @property {string} wranglerEnv - The wrangler environment to use for the test worker.
  */
 
 /**
  * Worker information object
- * @type {WorkerInfo}
+ * @type {WorkerInfo | undefined}
  */
-const workerInfo = {
-  ip: undefined,
-  port: undefined,
-  stop: undefined,
-  getOutput: undefined,
-  wranglerEnv: process.env.WRANGLER_ENV || 'integration'
-}
+let workerInfo;
 
 /**
  * Sets up the test worker.
@@ -34,13 +33,12 @@ const workerInfo = {
  */
 export const mochaGlobalSetup = async () => {
   try {
-    const result = await runWranglerDev(
+    workerInfo = await runWranglerDev(
       resolve(__dirname, '../../'), // The directory of the worker with the wrangler.toml
       ['--local'],
       process.env,
-      workerInfo.wranglerEnv
+      wranglerEnv
     )
-    Object.assign(workerInfo, result)
     console.log(`Output: ${await workerInfo.getOutput()}`)
     console.log('WorkerInfo:', workerInfo)
     console.log('Test worker started!')
@@ -55,6 +53,9 @@ export const mochaGlobalSetup = async () => {
  * @returns {Promise<void>}
  */
 export const mochaGlobalTeardown = async () => {
+  // If the worker is not running, nothing to do.
+  if (!workerInfo) return;
+
   try {
     const { stop } = workerInfo
     await stop?.()
@@ -71,5 +72,6 @@ export const mochaGlobalTeardown = async () => {
  * @returns {WorkerInfo}
  */
 export function getWorkerInfo () {
+  if (!workerInfo) throw new Error('Worker not running.');
   return workerInfo
 }

--- a/test/helpers/run-wrangler.js
+++ b/test/helpers/run-wrangler.js
@@ -103,7 +103,7 @@ async function runLongLivedWrangler (
           wranglerProcess.pid,
                   `Command "${command.join(' ')}" had no process id`
         )
-        treeKill(wranglerProcess.pid, (e) => {
+        treeKill(wranglerProcess.pid, 'SIGKILL', (e) => {
           if (e) {
             console.error(
               'Failed to kill command: ' + command.join(' '),

--- a/test/helpers/run-wrangler.js
+++ b/test/helpers/run-wrangler.js
@@ -62,70 +62,58 @@ async function runLongLivedWrangler (
   cwd,
   env
 ) {
-  let settledReadyPromise = false
-  /** @type {(value: { ip: string port: number }) => void} */
-  let resolveReadyPromise
-  /** @type {(reason: unknown) => void} */
-  let rejectReadyPromise
-
-  const ready = new Promise((resolve, reject) => {
-    resolveReadyPromise = resolve
-    rejectReadyPromise = reject
-  })
-
-  const wranglerProcess = fork(wranglerEntryPath, command, {
-    stdio: ['ignore', /* stdout */ 'pipe', /* stderr */ 'pipe', 'ipc'],
-    cwd,
-    env: { ...process.env, ...env, PWD: cwd }
-  }).on('message', (message) => {
-    if (settledReadyPromise) return
-    settledReadyPromise = true
-    clearTimeout(timeoutHandle)
-    resolveReadyPromise(JSON.parse(message.toString()))
-  })
-
-  const chunks = []
-  wranglerProcess.stdout?.on('data', (chunk) => {
-    chunks.push(chunk)
-  })
-  wranglerProcess.stderr?.on('data', (chunk) => {
-    chunks.push(chunk)
-  })
-  const getOutput = () => Buffer.concat(chunks).toString()
-  const clearOutput = () => (chunks.length = 0)
-
-  const timeoutHandle = setTimeout(() => {
-    if (settledReadyPromise) return
-    settledReadyPromise = true
-    const separator = '='.repeat(80)
-    const message = [
-      'Timed out starting long-lived Wrangler:',
-      separator,
-      getOutput(),
-      separator
-    ].join('\n')
-    rejectReadyPromise(new Error(message))
-  }, 50_000)
-
-  async function stop () {
-    return new Promise((resolve) => {
-      assert(
-        wranglerProcess.pid,
-                `Command "${command.join(' ')}" had no process id`
-      )
-      treeKill(wranglerProcess.pid, (e) => {
-        if (e) {
-          console.error(
-            'Failed to kill command: ' + command.join(' '),
-            wranglerProcess.pid,
-            e
-          )
-        }
-        resolve()
-      })
+  return new Promise((resolve, reject) => {
+    const wranglerProcess = fork(wranglerEntryPath, command, {
+      stdio: ['ignore', /* stdout */ 'pipe', /* stderr */ 'pipe', 'ipc'],
+      cwd,
+      env: { ...process.env, ...env, PWD: cwd }
+    }).on('message', (messageJSON) => {
+      clearTimeout(timeoutHandle)
+      /** @type {{ ip: string, port: number }} */
+      const message = JSON.parse(messageJSON.toString())
+      resolve({...message, stop, getOutput, clearOutput})
     })
-  }
 
-  const { ip, port } = await ready
-  return { ip, port, stop, getOutput, clearOutput }
+    /** @type {Buffer[]} */
+    const chunks = []
+    wranglerProcess.stdout?.on('data', (chunk) => {
+      chunks.push(chunk)
+    })
+    wranglerProcess.stderr?.on('data', (chunk) => {
+      chunks.push(chunk)
+    })
+    const getOutput = () => Buffer.concat(chunks).toString()
+    const clearOutput = () => (chunks.length = 0)
+
+    const timeoutHandle = setTimeout(() => {
+      const separator = '='.repeat(80)
+      const message = [
+        'Timed out starting long-lived Wrangler:',
+        separator,
+        getOutput(),
+        separator
+      ].join('\n')
+      reject(new Error(message))
+    }, 50_000)
+
+    /** @type {WranglerProcessInfo['stop']} */
+    async function stop () {
+      return new Promise((resolve) => {
+        assert(
+          wranglerProcess.pid,
+                  `Command "${command.join(' ')}" had no process id`
+        )
+        treeKill(wranglerProcess.pid, (e) => {
+          if (e) {
+            console.error(
+              'Failed to kill command: ' + command.join(' '),
+              wranglerProcess.pid,
+              e
+            )
+          }
+          resolve()
+        })
+      })
+    }
+  })
 }

--- a/test/helpers/run-wrangler.js
+++ b/test/helpers/run-wrangler.js
@@ -71,7 +71,7 @@ async function runLongLivedWrangler (
       clearTimeout(timeoutHandle)
       /** @type {{ ip: string, port: number }} */
       const message = JSON.parse(messageJSON.toString())
-      resolve({...message, stop, getOutput, clearOutput})
+      resolve({ ...message, stop, getOutput, clearOutput })
     })
 
     /** @type {Buffer[]} */

--- a/test/miniflare/freeway.spec.js
+++ b/test/miniflare/freeway.spec.js
@@ -13,6 +13,8 @@ import { Builder, toBlobKey } from '../helpers/builder.js'
 import { generateBlockLocationClaims, mockClaimsService, generateLocationClaim } from '../helpers/content-claims.js'
 import { mockBucketService } from '../helpers/bucket.js'
 
+/** @import { Block, Position } from 'carstream' */
+
 /**
  * @param {{ arrayBuffer: () => Promise<ArrayBuffer> }} a
  * @param {{ arrayBuffer: () => Promise<ArrayBuffer> }} b
@@ -163,6 +165,7 @@ describe('freeway', () => {
     const source = /** @type {ReadableStream<Uint8Array>} */ (res.body)
     const carStream = new CARReaderStream()
 
+    /** @type {(Block & Position)[]} */
     const blocks = []
     await source.pipeThrough(carStream).pipeTo(new WritableStream({
       write: (block) => { blocks.push(block) }
@@ -221,6 +224,7 @@ describe('freeway', () => {
     const source = /** @type {ReadableStream<Uint8Array>} */ (obj.body)
     const carStream = new CARReaderStream()
 
+    /** @type {(Block & Position)[]} */
     const blocks = []
     await source.pipeThrough(carStream).pipeTo(new WritableStream({
       write: (block) => { blocks.push(block) }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 
 {
-  "include": ["src"],
+  "include": ["src", "test"],
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
This is more what I was getting at with https://github.com/storacha/freeway/pull/116/files#r1787752932. This avoids some of the stashing and mutation by putting more inside the `new Promise()` construction itself.

I've also pulled `wranglerEnv` out into its own `const`, because it's actually an _input_, not an output. Then I've made `workerInfo` a `let` which is assigned when Wrangler boots, and is `undefined` before that, signaling that Wrangler is not yet available. The previous code was failing because there were `undefined` fields that aren't typed to allow `undefined`. Which wasn't an issue until…

I also turned type checking on in `test/`, because apparently it wasn't already. 😛 And lastly, I've ignored `.wrangler`, because Wrangler writes to that when it runs.