### PR TITLE
feat(blob-fetcher): use updated blob fetcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.20.2",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@web3-storage/blob-fetcher": "^2.2.0",
+        "@web3-storage/blob-fetcher": "^2.3.1",
         "@web3-storage/gateway-lib": "^5.1.2",
         "dagula": "^8.0.0",
         "http-range-parse": "^1.0.0",
@@ -373,10 +373,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20240919.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20240919.0.tgz",
-      "integrity": "sha512-DZwTpZVAV+fKTLxo6ntC2zMNRL/UJwvtMKUt/U7ZyJdR+t0qcBUZGx8jLi9gOFWYxkzO3s7slajwkR2hQRPXYQ==",
-      "dev": true
+      "version": "4.20241022.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20241022.0.tgz",
+      "integrity": "sha512-1zOAw5QIDKItzGatzCrEpfLOB1AuMTwVqKmbw9B9eBfCUGRFNfJYMrJxIwcse9EmKahsQt2GruqU00pY/GyXgg=="
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -3551,10 +3550,11 @@
       "dev": true
     },
     "node_modules/@web3-storage/blob-fetcher": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/blob-fetcher/-/blob-fetcher-2.2.0.tgz",
-      "integrity": "sha512-JsbvcJ9aPOxjnqGZzTMyQbUoFHeWyHs7UfvT0U4eKf23UOxC39MTHxiBznikALg2i0jgnvBCx+pa2P+WIIIAJw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@web3-storage/blob-fetcher/-/blob-fetcher-2.3.1.tgz",
+      "integrity": "sha512-yjtj0z+GcQY99smXGvKVcaac7MZFXepWw2VOruUojLMlgW3u1lEx19yqM+xHutMpUQMO51166Qvsm14as8Rlfg==",
       "dependencies": {
+        "@cloudflare/workers-types": "^4.20241022.0",
         "@ucanto/interface": "^10.0.1",
         "@web3-storage/blob-index": "^1.0.2",
         "@web3-storage/content-claims": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "author": "Alan Shaw",
   "license": "Apache-2.0 OR MIT",
   "dependencies": {
-    "@web3-storage/blob-fetcher": "^2.2.0",
+    "@web3-storage/blob-fetcher": "^2.3.1",
     "@web3-storage/gateway-lib": "^5.1.2",
     "dagula": "^8.0.0",
     "http-range-parse": "^1.0.0",

--- a/src/middleware/withLocator.js
+++ b/src/middleware/withLocator.js
@@ -22,6 +22,10 @@ export function withLocator (handler) {
     const locator = ContentClaimsLocator.create({
       serviceURL: env.CONTENT_CLAIMS_SERVICE_URL
         ? new URL(env.CONTENT_CLAIMS_SERVICE_URL)
+        : undefined,
+      carpark: env.CARPARK,
+      carparkPublicBucketURL: env.CARPARK_PUBLIC_BUCKET_URL
+        ? new URL(env.CARPARK_PUBLIC_BUCKET_URL)
         : undefined
     })
     return handler(request, env, { ...ctx, locator })

--- a/src/middleware/withLocator.types.ts
+++ b/src/middleware/withLocator.types.ts
@@ -3,9 +3,12 @@ import {
   Environment as MiddlewareEnvironment,
   Context as MiddlewareContext,
 } from '@web3-storage/gateway-lib'
+import { R2Bucket } from '@cloudflare/workers-types'
 
 export interface LocatorEnvironment extends MiddlewareEnvironment {
   CONTENT_CLAIMS_SERVICE_URL?: string
+  CARPARK: R2Bucket
+  CARPARK_PUBLIC_BUCKET_URL?: string
 }
 
 export interface LocatorContext extends MiddlewareContext {

--- a/test/helpers/bucket.js
+++ b/test/helpers/bucket.js
@@ -1,11 +1,8 @@
-import http from 'node:http'
 import * as PublicBucket from '@web3-storage/public-bucket/server/node'
 
 /**
  * @typedef {import('@web3-storage/public-bucket').Bucket} Bucket
  * @typedef {{
- *   url: URL
- *   close: () => void
  *   getCallCount: () => number
  *   resetCallCount: () => void
  * }} MockBucketService
@@ -13,25 +10,18 @@ import * as PublicBucket from '@web3-storage/public-bucket/server/node'
 
 /**
  * @param {Bucket} bucket
+ * @param {import('node:http').Server} server
  * @returns {Promise<MockBucketService>}
  */
-export const mockBucketService = async (bucket) => {
+export const mockBucketService = async (bucket, server) => {
   let callCount = 0
   const getCallCount = () => callCount
   const resetCallCount = () => { callCount = 0 }
 
   const handler = PublicBucket.createHandler({ bucket })
-  const server = http.createServer((request, response) => {
+  server.on('request', (request, response) => {
     callCount++
     handler(request, response)
   })
-  await new Promise(resolve => server.listen(resolve))
-  const close = () => {
-    server.closeAllConnections()
-    server.close()
-  }
-  // @ts-expect-error
-  const { port } = server.address()
-  const url = new URL(`http://127.0.0.1:${port}`)
-  return { close, getCallCount, resetCallCount, url }
+  return { getCallCount, resetCallCount }
 }

--- a/test/helpers/content-claims.js
+++ b/test/helpers/content-claims.js
@@ -74,6 +74,24 @@ export const generateLocationClaim = async (signer, content, location, offset, l
 }
 
 /**
+ * @param {import('@ucanto/interface').Signer} signer
+ * @param {import('multiformats').UnknownLink} content
+ * @param {import('multiformats').Link} index
+ */
+export const generateIndexClaim = async (signer, content, index) => {
+  const invocation = Assert.index.invoke({
+    issuer: signer,
+    audience: signer,
+    with: signer.did(),
+    nb: {
+      content,
+      index
+    }
+  })
+  return await encode(invocation)
+}
+
+/**
  * Encode a claim to a block.
  * @param {import('@ucanto/interface').IPLDViewBuilder<import('@ucanto/interface').Delegation>} invocation
  */

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -45,6 +45,7 @@ MAX_SHARDS = "825"
 FF_RATE_LIMITER_ENABLED = "false"
 FF_EGRESS_TRACKER_ENABLED = "false"
 CONTENT_CLAIMS_SERVICE_URL = "https://claims.web3.storage"
+CARPARK_PUBLIC_BUCKET_URL = "https://carpark-prod-0.r2.w3s.link"
 
 # Staging!
 [env.staging]
@@ -62,6 +63,7 @@ MAX_SHARDS = "825"
 FF_RATE_LIMITER_ENABLED = "false"
 FF_EGRESS_TRACKER_ENABLED = "false"
 CONTENT_CLAIMS_SERVICE_URL = "https://staging.claims.web3.storage"
+CARPARK_PUBLIC_BUCKET_URL = "https://carpark-staging-0.r2.w3s.link"
 
 # Test!
 [env.test]
@@ -117,6 +119,21 @@ simple = { limit = 5, period = 60 }
 binding = "AUTH_TOKEN_METADATA"
 id = "f848730e45d94f17bcaf3b6d0915da40"
 
+
+[env.hannahhoward]
+name = "freeway-hannahhoward"
+workers_dev = true
+account_id = "fffa4b4363a7e5250af8357087263b3a"
+r2_buckets = [
+  { binding = "CARPARK", bucket_name = "carpark-prod-0", preview_bucket_name = "carpark-prod-0" }
+]
+
+[env.hannahhoward.vars]
+DEBUG = "true"
+FF_RATE_LIMITER_ENABLED = "false"
+FF_EGRESS_TRACKER_ENABLED = "false"
+CONTENT_CLAIMS_SERVICE_URL = "https://claims.web3.storage"
+CARPARK_PUBLIC_BUCKET_URL = "https://carpark-prod-0.r2.w3s.link"
 
 ### Integration Tests Configuration
 [env.integration]


### PR DESCRIPTION
# Goals

Read sharded dag indexes properly, even in the absense of location claims

# Implementation

- use update blob-fetcher
- pass values to enable carpark fallback
- add two tests to verify:
   - that normal index shard fetching works in the presence of location claims
   - that in the absense of location claims it can fill in the missing values.