### PR TITLE
fix(test): enable nodejs compat for miniflare

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -13,12 +13,27 @@ runs:
       shell: bash
     - run: npm run lint
       shell: bash
-    - run: npm run test:unit
+    - run: |
+        npm run test:unit
+        if [ $? -ne 0 ]; then
+          echo "Unit Tests failed"
+          exit 1
+        fi
       name: Unit Tests
       shell: bash
-    - run: npm run test:miniflare
-      name: Miniflare Tests
-      shell: bash
-    - run: npm run test:integration
+    - run: |
+        npm run test:integration
+        if [ $? -ne 0 ]; then
+          echo "Integration Tests failed"
+          exit 1
+        fi
       name: Integration Tests
+      shell: bash
+    - run: |
+        npm run test:miniflare
+        if [ $? -ne 0 ]; then
+          echo "Miniflare Tests failed"
+          exit 1
+        fi
+      name: Miniflare Tests
       shell: bash

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -13,26 +13,20 @@ runs:
       shell: bash
     - run: npm run lint
       shell: bash
-    - run: |
-        npm run test:unit
-        if [ $? -ne 0 ]; then
-          echo "Unit Tests failed"
-          exit 1
-        fi
+    - run: npm run test:unit
       name: Unit Tests
       shell: bash
-    - run: |
-        npm run test:integration
-        if [ $? -ne 0 ]; then
-          echo "Integration Tests failed"
-          exit 1
-        fi
+    - run: npm run test:integration
       name: Integration Tests
       shell: bash
     - run: |
-        npm run test:miniflare
-        if [ $? -ne 0 ]; then
-          echo "Miniflare Tests failed"
+        # If the Miniflare tests fail we need to capture the output and check for the error,
+        # because the error is not bubbled up from miniflare and the tests will pass.
+        npm run test:miniflare | tee test-output.log
+
+        # Check for the error in the output to fail the test action
+        if grep -q 'ERR_TEST_FAILURE' test-output.log; then
+          echo "Test failure detected: ERR_TEST_FAILURE"
           exit 1
         fi
       name: Miniflare Tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "standard": "^17.1.0",
         "tree-kill": "^1.2.2",
         "typescript": "^5.6.3",
-        "wrangler": "^3.78.8"
+        "wrangler": "^3.84.1"
       }
     },
     "node_modules/@achingbrain/ip-address": {
@@ -284,9 +284,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20240909.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20240909.0.tgz",
-      "integrity": "sha512-nJ8jm/6PR8DPzVb4QifNAfSdrFZXNblwIdOhLTU5FpSvFFocmzFX5WgzQagvtmcC9/ZAQyxuf7WynDNyBcoe0Q==",
+      "version": "1.20241022.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20241022.0.tgz",
+      "integrity": "sha512-1NNYun37myMTgCUiPQEJ0cMal4mKZVTpkD0b2tx9hV70xji+frVJcSK8YVLeUm1P+Rw1d/ct8DMgQuCpsz3Fsw==",
       "cpu": [
         "x64"
       ],
@@ -300,9 +300,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20240909.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20240909.0.tgz",
-      "integrity": "sha512-gJqKa811oSsoxy9xuoQn7bS0Hr1sY+o3EUORTcEnulG6Kz9NQ6nd8QNdp2Hrk2jmmSqwrNkn+a6PZkWzk6Q0Gw==",
+      "version": "1.20241022.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20241022.0.tgz",
+      "integrity": "sha512-FOO/0P0U82EsTLTdweNVgw+4VOk5nghExLPLSppdOziq6IR5HVgP44Kmq5LdsUeHUhwUmfOh9hzaTpkNzUqKvw==",
       "cpu": [
         "arm64"
       ],
@@ -316,9 +316,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20240909.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20240909.0.tgz",
-      "integrity": "sha512-sJrmtccfMg73sZljiBpe4R+lhF58TqzqhF2pQG8HRjyxkzkM1sjpZqfEFaIkNUDqd3/Ibji49fklhPCGXljKSg==",
+      "version": "1.20241022.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20241022.0.tgz",
+      "integrity": "sha512-RsNc19BQJG9yd+ngnjuDeG9ywZG+7t1L4JeglgceyY5ViMNMKVO7Zpbsu69kXslU9h6xyQG+lrmclg3cBpnhYA==",
       "cpu": [
         "x64"
       ],
@@ -332,9 +332,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20240909.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20240909.0.tgz",
-      "integrity": "sha512-dTbSdceyRXPOSER+18AwYRbPQG0e/Dwl2trmfMMCETkfJhNLv1fU3FFMJPjfILijKnhTZHSnHCx0+xwHdon2fg==",
+      "version": "1.20241022.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20241022.0.tgz",
+      "integrity": "sha512-x5mUXpKxfsosxcFmcq5DaqLs37PejHYVRsNz1cWI59ma7aC4y4Qn6Tf3i0r9MwQTF/MccP4SjVslMU6m4W7IaA==",
       "cpu": [
         "arm64"
       ],
@@ -348,9 +348,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20240909.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20240909.0.tgz",
-      "integrity": "sha512-/d4BT0kcWFa7Qc0K4K9+cwVQ1qyPNKiO42JZUijlDlco+TYTPkLO3qGEohmwbfMq+BieK7JTMSgjO81ZHpA0HQ==",
+      "version": "1.20241022.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20241022.0.tgz",
+      "integrity": "sha512-eBCClx4szCOgKqOlxxbdNszMqQf3MRG1B9BRIqEM/diDfdR9IrZ8l3FaEm+l9gXgPmS6m1NBn40aWuGBl8UTSw==",
       "cpu": [
         "x64"
       ],
@@ -364,9 +364,9 @@
       }
     },
     "node_modules/@cloudflare/workers-shared": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-shared/-/workers-shared-0.5.4.tgz",
-      "integrity": "sha512-PNL/0TjKRdUHa1kwgVdqUNJVZ9ez4kacsi8omz+gv859EvJmsVuGiMAClY2YfJnC9LVKhKCcjqmFgKNXG9/IXA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-shared/-/workers-shared-0.7.0.tgz",
+      "integrity": "sha512-LLQRTqx7lKC7o2eCYMpyc5FXV8d0pUX6r3A+agzhqS9aoR5A6zCPefwQGcvbKx83ozX22ATZcemwxQXn12UofQ==",
       "dev": true,
       "dependencies": {
         "mime": "^3.0.0",
@@ -6642,9 +6642,9 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "dev": true,
       "funding": {
         "type": "github",
@@ -9634,6 +9634,12 @@
         "set-function-name": "^2.0.1"
       }
     },
+    "node_modules/itty-time": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/itty-time/-/itty-time-1.0.6.tgz",
+      "integrity": "sha512-+P8IZaLLBtFv8hCkIjcymZOp4UJ+xW6bSlQsXGqrkmJh7vSiMFSlNne0mCYagEE0N7HDNR5jJBRxwN0oYv61Rw==",
+      "dev": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10305,9 +10311,9 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "3.20240909.5",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20240909.5.tgz",
-      "integrity": "sha512-3Am3D9LGDljEKWnylSy6hFg3LFnNCo9DlWqZFcL7QkuIhQwN6Sqz1d6xQCkgft7FVXnykG6VNpz0NrjdW+mBjg==",
+      "version": "3.20241022.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20241022.0.tgz",
+      "integrity": "sha512-x9Fbq1Hmz1f0osIT9Qmj78iX4UpCP2EqlZnA/tzj/3+I49vc3Kq0fNqSSKplcdf6HlCHdL3fOBicmreQF4BUUQ==",
       "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
@@ -10318,7 +10324,7 @@
         "glob-to-regexp": "^0.4.1",
         "stoppable": "^1.1.0",
         "undici": "^5.28.4",
-        "workerd": "1.20240909.0",
+        "workerd": "1.20241022.0",
         "ws": "^8.17.1",
         "youch": "^3.2.2",
         "zod": "^3.22.3"
@@ -12989,9 +12995,9 @@
     },
     "node_modules/unenv": {
       "name": "unenv-nightly",
-      "version": "2.0.0-20240919-125358-9a64854",
-      "resolved": "https://registry.npmjs.org/unenv-nightly/-/unenv-nightly-2.0.0-20240919-125358-9a64854.tgz",
-      "integrity": "sha512-XjsgUTrTHR7iw+k/SRTNjh6EQgwpC9voygnoCJo5kh4hKqsSDHUW84MhL9EsHTNfLctvVBHaSw8e2k3R2fKXsQ==",
+      "version": "2.0.0-20241024-111401-d4156ac",
+      "resolved": "https://registry.npmjs.org/unenv-nightly/-/unenv-nightly-2.0.0-20241024-111401-d4156ac.tgz",
+      "integrity": "sha512-xJO1hfY+Te+/XnfCYrCbFbRcgu6XEODND1s5wnVbaBCkuQX7JXF7fHEXPrukFE2j8EOH848P8QN19VO47XN8hw==",
       "dev": true,
       "dependencies": {
         "defu": "^6.1.4",
@@ -13300,9 +13306,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20240909.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20240909.0.tgz",
-      "integrity": "sha512-NwuYh/Fgr/MK0H+Ht687sHl/f8tumwT5CWzYR0MZMHri8m3CIYu2IaY4tBFWoKE/tOU1Z5XjEXECa9zXY4+lwg==",
+      "version": "1.20241022.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20241022.0.tgz",
+      "integrity": "sha512-jyGXsgO9DRcJyx6Ovv7gUyDPc3UYC2i/E0p9GFUg6GUzpldw4Y93y9kOmdfsOnKZ3+lY53veSiUniiBPE6Q2NQ==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -13312,11 +13318,11 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20240909.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20240909.0",
-        "@cloudflare/workerd-linux-64": "1.20240909.0",
-        "@cloudflare/workerd-linux-arm64": "1.20240909.0",
-        "@cloudflare/workerd-windows-64": "1.20240909.0"
+        "@cloudflare/workerd-darwin-64": "1.20241022.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20241022.0",
+        "@cloudflare/workerd-linux-64": "1.20241022.0",
+        "@cloudflare/workerd-linux-arm64": "1.20241022.0",
+        "@cloudflare/workerd-windows-64": "1.20241022.0"
       }
     },
     "node_modules/workerpool": {
@@ -13326,28 +13332,29 @@
       "dev": true
     },
     "node_modules/wrangler": {
-      "version": "3.78.8",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.78.8.tgz",
-      "integrity": "sha512-tnJ++KY0EeQKa7Pm5Zxl1Cnf1QcmlLit2CohCpTEFHSgCzwzwViuxFL8JQvVKj8Qb65ouBNbfPZnlqrEyGpbew==",
+      "version": "3.84.1",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.84.1.tgz",
+      "integrity": "sha512-w27/QpIk2qz6aMIVi9T8cDcXMvh/RXjcL+vf4o5J2GpQAE4U7wTCNHyaY9H3oTJWRN97KqCAEbiHBNtTKoUJEw==",
       "dev": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.3.4",
-        "@cloudflare/workers-shared": "0.5.4",
+        "@cloudflare/workers-shared": "0.7.0",
         "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
         "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
         "blake3-wasm": "^2.1.5",
         "chokidar": "^3.5.3",
-        "date-fns": "^3.6.0",
+        "date-fns": "^4.1.0",
         "esbuild": "0.17.19",
-        "miniflare": "3.20240909.5",
+        "itty-time": "^1.0.6",
+        "miniflare": "3.20241022.0",
         "nanoid": "^3.3.3",
         "path-to-regexp": "^6.3.0",
         "resolve": "^1.22.8",
         "resolve.exports": "^2.0.2",
         "selfsigned": "^2.0.1",
         "source-map": "^0.6.1",
-        "unenv": "npm:unenv-nightly@2.0.0-20240919-125358-9a64854",
-        "workerd": "1.20240909.0",
+        "unenv": "npm:unenv-nightly@2.0.0-20241024-111401-d4156ac",
+        "workerd": "1.20241022.0",
         "xxhash-wasm": "^1.0.1"
       },
       "bin": {
@@ -13361,7 +13368,7 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20240909.0"
+        "@cloudflare/workers-types": "^4.20241022.0"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "standard": "^17.1.0",
     "tree-kill": "^1.2.2",
     "typescript": "^5.6.3",
-    "wrangler": "^3.78.8"
+    "wrangler": "^3.84.1"
   },
   "standard": {
     "ignore": [

--- a/test/miniflare/freeway.spec.js
+++ b/test/miniflare/freeway.spec.js
@@ -55,8 +55,7 @@ describe('freeway', () => {
       },
       scriptPath: 'dist/worker.mjs',
       modules: true,
-      compatibilityFlags: ['nodejs_compat'],
-      compatibilityDate: '2024-09-23',
+      compatibilityDate: '2023-06-17',
       r2Buckets: ['CARPARK']
     })
 

--- a/test/miniflare/freeway.spec.js
+++ b/test/miniflare/freeway.spec.js
@@ -55,7 +55,8 @@ describe('freeway', () => {
       },
       scriptPath: 'dist/worker.mjs',
       modules: true,
-      compatibilityDate: '2023-06-17',
+      compatibilityFlags: ['nodejs_compat'],
+      compatibilityDate: '2024-09-23',
       r2Buckets: ['CARPARK']
     })
 


### PR DESCRIPTION
### Fix for Node.js Built-in Module Resolution in Cloudflare Worker Miniflare Tests

#### **Overview**
This PR addresses an issue with resolving Node.js built-in modules (`node:buffer`, `node:events`, `node:async_hooks`) in a Cloudflare Worker Test environment. The Worker encountered errors in resolving these built-in modules, which aren’t natively supported in Workers. 

This issue was introduced when the [Opentelemetry PR was merged](https://github.com/storacha/freeway/pull/125), but we didn't see that because the Github Action that runs the `test:miniflare` was not flagging the test failure. 

#### **Error Description**
During testing, the following error appeared:
```
Unable to resolve "dist/worker.mjs" dependency "node:buffer": no matching module rules.
If you're trying to import a Node.js built-in module, or an npm package that uses Node.js built-ins, you'll either need to:
- Bundle your Worker, configuring your bundler to polyfill Node.js built-ins
- Configure your bundler to load Workers-compatible builds by changing the main fields/conditions
- Enable the `nodejs_compat` compatibility flag and use the `NodeJsCompatModule` module type
- Find an alternative package that doesn't require Node.js built-ins
```

#### **Solution**

1. To resolve this, I've enabled the `nodejs_compat` compatibility flag in the `test/miniflare/freeway.spec.js` file - which allows the Cloudflare Miniflare Worker to utilize Node.js runtime APIs, and set the compatibility date to "2024-09-23", as suggested in their docs: https://developers.cloudflare.com/workers/runtime-apis/nodejs/#get-started

2. Updated the Github Action to halt the execution in case of test failures

3. Updated the wrangler package to clean up some warnings during the integration tests.


#### **Note**
As of September 23, 2024, enabling `nodejs_compat` applies the same behavior as `nodejs_compat_v2` for compatibility dates set to September 23, 2024 or later, meaning this configuration is fully aligned with the latest runtime support for Node.js compatibility in Workers.