### PR TITLE
fix(egress-client): set nonce, expire and fix servedAt

### DIFF
--- a/src/middleware/withEgressClient.js
+++ b/src/middleware/withEgressClient.js
@@ -89,8 +89,10 @@ async function record (space, resource, bytes, servedAt, env, ctx) {
     nb: {
       resource,
       bytes,
-      servedAt: Math.floor(servedAt.getTime() / 1000)
+      servedAt: servedAt.getTime()
     },
+    expiration: Infinity, // Don't expire the invocation, so we can record egress any time
+    nonce: process.hrtime().toString(),
     proofs: ctx.delegationProofs
   })
   const res = await invocation.execute(connection)


### PR DESCRIPTION
Added the `nonce` as suggested per @alanshaw, but also set it to not expire, so we can process the invocation any time. The `servedAt` field doesn't need to be converted to seconds.

Blocked by https://github.com/storacha/w3infra/pull/443 & https://github.com/storacha/w3up/pull/1588