### PR TITLE
fix(freeway): enable tracing properly and resolve fetch issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -133,8 +133,11 @@ let handlerPromise = null
  */
 async function initializeHandler (env) {
   const baseHandler = middleware(handleUnixfs)
+  if (env.FF_TELEMETRY_ENABLED === 'true') {
+    globalThis.fetch = globalThis.fetch.bind(globalThis)
+  }
   const finalHandler = env.FF_TELEMETRY_ENABLED === 'true'
-    ? instrument(baseHandler, config)
+    ? /** @type {Handler<Context, Environment>} */(instrument({ fetch: baseHandler }, config).fetch)
     : baseHandler
   return finalHandler
 }


### PR DESCRIPTION
# Goals

in #131 we believed https://github.com/storacha/project-tracking/issues/176 was solved. however, it turns out updates to freeway actually just prevented tracing from getting enabled properly, and the underlying issue remained.

# Implementation

- bind globalthis.fetch to itself (this is the proper fix to https://github.com/storacha/project-tracking/issues/176)
- properly enable tracing