### PR TITLE
chore(prod): enable worker logs

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -63,6 +63,10 @@ CARPARK_PUBLIC_BUCKET_URL = "https://carpark-prod-0.r2.w3s.link"
 UPLOAD_API_URL = "https://up.web3.storage"
 INDEXING_SERVICE_URL = "https://indexer.storacha.network/"
 
+[env.production.observability]
+enabled = true
+head_sampling_rate = 0.01 
+
 # Staging!
 [env.staging]
 account_id = "fffa4b4363a7e5250af8357087263b3a"


### PR DESCRIPTION
### Context
- Egress event was not sent to the SQS Queue in AWS, and there is no easy way to find the error with the Live Stream of requests in the Worker due to the volume of requests we receive. 
- To help troubleshoot the issue this PR enables the worker logs with 1% sampling.