### PR TITLE
feat(freeway): put prod indexer usage to 50%

### DIFF
--- a/src/middleware/withLocator.js
+++ b/src/middleware/withLocator.js
@@ -1,6 +1,7 @@
 import { ContentClaimsClient } from '@web3-storage/blob-fetcher/locator/content-claims-client'
 import * as Locator from '@web3-storage/blob-fetcher/locator'
 import { Client } from '@storacha/indexing-service-client'
+import { trace } from '@opentelemetry/api'
 
 /**
  * @import {
@@ -22,7 +23,10 @@ import { Client } from '@storacha/indexing-service-client'
 export function withLocator (handler) {
   return async (request, env, ctx) => {
     const useIndexingService = isIndexingServiceEnabled(request, env)
-
+    const span = trace.getActiveSpan()
+    if (span) {
+      span.setAttribute('useIndexingService', useIndexingService)
+    }
     const client = useIndexingService
       ? new Client({
         serviceURL: env.INDEXING_SERVICE_URL

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -55,7 +55,7 @@ FF_RATE_LIMITER_ENABLED = "false"
 FF_EGRESS_TRACKER_ENABLED = "true"
 FF_TELEMETRY_ENABLED = "true"
 FF_DELEGATIONS_STORAGE_ENABLED = "true"
-FF_RAMP_UP_PROBABILITY = "10"
+FF_RAMP_UP_PROBABILITY = "50"
 # Cache for 30 days by default
 FF_DAGPB_CONTENT_CACHE_TTL_SECONDS = 2_592_000
 FF_DAGPB_CONTENT_CACHE_MAX_SIZE_MB = 2
@@ -206,6 +206,11 @@ account_id = "fffa4b4363a7e5250af8357087263b3a"
 r2_buckets = [
   { binding = "CARPARK", bucket_name = "carpark-prod-0", preview_bucket_name = "carpark-prod-0" }
 ]
+kv_namespaces = [
+  { binding = "AUTH_TOKEN_METADATA", id = "b618bb05deb8493f944ef4a0f538030c", preview_id = "6a546b5fc21a423eb4ea07db2d611a91" },
+  { binding = "CONTENT_SERVE_DELEGATIONS_STORE", id = "26cc47fec09749bb9ee42bc6407f9a9d", preview_id = "ec5c429f8b1849a68d73dee7447b4e30" },
+  { binding = "DAGPB_CONTENT_CACHE", id = "3f0c253b90fc48c1b384f1563ede54f9", preview_id = "fcea72d8d8694b5c831736e1317e9208" }
+]
 
 [env.hannahhoward.vars]
 DEBUG = "true"
@@ -218,12 +223,18 @@ FF_DAGPB_CONTENT_CACHE_TTL_SECONDS = 300
 FF_DAGPB_CONTENT_CACHE_MAX_SIZE_MB = 2
 FF_DAGPB_CONTENT_CACHE_ENABLED = "true"
 TELEMETRY_RATIO = 1.0
-GATEWAY_SERVICE_DID = "did:web:staging.w3s.link"
-UPLOAD_SERVICE_DID = "did:web:staging.web3.storage"
 CONTENT_CLAIMS_SERVICE_URL = "https://claims.web3.storage"
 CARPARK_PUBLIC_BUCKET_URL = "https://carpark-prod-0.r2.w3s.link"
-UPLOAD_API_URL = "https://staging.up.web3.storage"
 INDEXING_SERVICE_URL = "https://indexer.storacha.network/"
+GATEWAY_SERVICE_DID = "did:web:w3s.link"
+UPLOAD_SERVICE_DID = "did:web:web3.storage"
+UPLOAD_API_URL = "https://up.web3.storage"
+
+[[env.hannahhoward.unsafe.bindings]]
+name = "RATE_LIMITER"
+type = "ratelimit"
+namespace_id = "0"
+simple = { limit = 5, period = 60 }
 
 [env.peeja]
 # Custom name for your testing/dev worker


### PR DESCRIPTION
# Goals

Put indexer traffic to 50% (10% seems to be doing fine)

# Implementation

- change prod var for indexer percentage
- also add a tag to root spans to track whether indexer was used
- remaining changes to wrangler.toml were just fixing my personal env