### PR TITLE
fix: handling legacy requests

### DIFF
--- a/src/middleware/withCarParkFetch.js
+++ b/src/middleware/withCarParkFetch.js
@@ -54,10 +54,12 @@ const MAX_BATCH_SIZE = 20 * 1024 * 1024
  */
 export function withCarParkFetch (handler) {
   return async (request, env, ctx) => {
-    // if carpark public bucket is not set, just use default
-    if (!env.CARPARK_PUBLIC_BUCKET_URL) {
+    const url = new URL(request.url)
+    const legacyRequest = url.searchParams.get('legacyReq') === 'true'
+    if (!env.CARPARK_PUBLIC_BUCKET_URL || legacyRequest) {
       return handler(request, env, { ...ctx, fetch: globalThis.fetch })
     }
+
     const bucket = new TraceBucket(/** @type {import('@web3-storage/public-bucket').Bucket} */ (env.CARPARK))
     const bucketHandler = createHandler({ bucket, maxBatchSize: MAX_BATCH_SIZE })
 


### PR DESCRIPTION

### Context

1. The content was uploaded before we implemented the current indexing and carpark system
2. Our current gateway tries to use the indexing service if enabled, if not, it will try to find in the carpark directly, but for some reason, it can't find it there as well
3. When neither system can find the content, the request fails, but if we disable both services, it will use content claims, and then it will find the correct location in the R2 carpark

### Solution
Add a `legacyReq=true` query parameter that allows bypassing both the indexing service and carpark systems. When this parameter is present:
- The request will skip the indexing service check
- The carpark functionality will be disabled
- The content will be resolved via the content claims service

This change has been implemented in two key places:
1. `withLocator.js`: Disables both indexing service and carpark when `legacyReq=true`
2. `withCarParkFetch.js`: Bypasses carpark fetch functionality when `legacyReq=true`
